### PR TITLE
Allow library dependencies to be defined in the pattern definition

### DIFF
--- a/src/Plugin/PatternBase.php
+++ b/src/Plugin/PatternBase.php
@@ -96,14 +96,18 @@ abstract class PatternBase extends PluginBase implements PatternInterface, Conta
   /**
    * Process libraries.
    *
-   * @param array $libraries
-   *    Libraries array.
+   * @param array|string $libraries
+   *    Libraries array or library string.
    * @param string $base_path
    *    Pattern base path.
    * @param string $parent
    *    Item parent set in previous recursive iteration, if any.
    */
-  protected function processLibraries(array &$libraries, $base_path, $parent = '') {
+  protected function processLibraries(&$libraries, $base_path, $parent = '') {
+    if(is_string($libraries)){
+      // Dependencies.
+      return;
+    }
     $parents = ['js', 'base', 'layout', 'component', 'state', 'theme'];
     $_libraries = $libraries;
     foreach ($_libraries as $name => $values) {


### PR DESCRIPTION
Library dependency definitions break the site. To keep with standard libaries.yml file structure, this small fix allows depencies to be declared.