### PR TITLE
Use getLabel on field definition

### DIFF
--- a/modules/ui_patterns_ds/src/Plugin/UiPatterns/Source/DsFieldTemplateSource.php
+++ b/modules/ui_patterns_ds/src/Plugin/UiPatterns/Source/DsFieldTemplateSource.php
@@ -59,7 +59,7 @@ class DsFieldTemplateSource extends PatternSourceBase implements ContainerFactor
 
     /** @var \Drupal\field\Entity\FieldConfig $field */
     $field = $this->fieldManager->getFieldDefinitions($entity_type, $bundle)[$field_name];
-    $label = $field->label();
+    $label = $field->getLabel();
 
     $sources[] = $this->getSourceField($field_name, $label);
     foreach ($field->getFieldStorageDefinition()->getColumns() as $column_name => $column) {


### PR DESCRIPTION
If you use patterns on computed fields, this code will crash. I think also on BaseFieldDefinitions.

Should use getLabel from FieldDefinition