### PR TITLE
Pattern Layouts don't render properly using Page Manager + Panels

### DIFF
--- a/modules/ui_patterns_layouts/src/Plugin/Layout/PatternLayout.php
+++ b/modules/ui_patterns_layouts/src/Plugin/Layout/PatternLayout.php
@@ -8,6 +8,7 @@ use Drupal\Core\Layout\LayoutDefinition;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\ui_patterns\UiPatternsManager;
+use Drupal\Core\Render\ElementInfoManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -25,6 +26,13 @@ class PatternLayout extends LayoutDefault implements PluginFormInterface, Contai
   protected $patternManager = NULL;
 
   /**
+   * The element info.
+   *
+   * @var \Drupal\Core\Render\ElementInfoManagerInterface
+   */
+  protected $elementInfo;
+
+  /**
    * Constructs a LocalActionDefault object.
    *
    * @param array $configuration
@@ -36,8 +44,9 @@ class PatternLayout extends LayoutDefault implements PluginFormInterface, Contai
    * @param \Drupal\ui_patterns\UiPatternsManager $pattern_manager
    *    Pattern manager service.
    */
-  public function __construct(array $configuration, $plugin_id, LayoutDefinition $plugin_definition, UiPatternsManager $pattern_manager) {
+  public function __construct(array $configuration, $plugin_id, LayoutDefinition $plugin_definition, ElementInfoManagerInterface $element_info, UiPatternsManager $pattern_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->elementInfo = $element_info;
     $this->patternManager = $pattern_manager;
   }
 
@@ -49,6 +58,7 @@ class PatternLayout extends LayoutDefault implements PluginFormInterface, Contai
       $configuration,
       $plugin_id,
       $plugin_definition,
+      $container->get('plugin.manager.element_info'),
       $container->get('plugin.manager.ui_patterns')
     );
   }
@@ -74,7 +84,7 @@ class PatternLayout extends LayoutDefault implements PluginFormInterface, Contai
       '#type' => 'pattern',
       '#id' => $this->getPluginDefinition()->get('additional')['pattern'],
       '#fields' => $fields,
-    ];
+    ] + $this->elementInfo->getInfo('pattern');
   }
 
   /**

--- a/modules/ui_patterns_test/config/install/page_manager.page.node_view.yml
+++ b/modules/ui_patterns_test/config/install/page_manager.page.node_view.yml
@@ -1,0 +1,18 @@
+uuid: c87caa1d-81c3-4082-b567-eb6d58f750c1
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: RCVWP-yHwxSNiQORMIabDgHMEVqOMW58w80BQgRFJ4k
+id: node_view
+label: 'Node view'
+description: 'When enabled, this overrides the default Drupal behavior for displaying nodes at <em>/node/{node}</em>. If you add variants, you may use selection criteria such as node type or language or user access to provide different views of nodes. If no variant is selected, the default Drupal node view will be used. This page only affects nodes viewed as pages, it will not affect nodes viewed in lists or at other locations.'
+use_admin_theme: false
+path: '/node/{node}'
+access_logic: and
+access_conditions: {  }
+parameters:
+  node:
+    machine_name: node
+    type: 'entity:node'
+    label: Node

--- a/modules/ui_patterns_test/config/install/page_manager.page.panels_test_page.yml
+++ b/modules/ui_patterns_test/config/install/page_manager.page.panels_test_page.yml
@@ -1,0 +1,12 @@
+uuid: aa48afee-a0bd-4e43-b58d-a2c759c83dff
+langcode: en
+status: true
+dependencies: {  }
+id: panels_test_page
+label: 'Panels Test Page'
+description: ''
+use_admin_theme: false
+path: /panels-test-page
+access_logic: and
+access_conditions: {  }
+parameters: {  }

--- a/modules/ui_patterns_test/config/install/page_manager.page_variant.panels_test_page-panels_variant-0.yml
+++ b/modules/ui_patterns_test/config/install/page_manager.page_variant.panels_test_page-panels_variant-0.yml
@@ -1,0 +1,37 @@
+uuid: 01d3ecac-e74a-478e-9c39-108eee15061b
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.panels_test_page
+  module:
+    - panels
+id: panels_test_page-panels_variant-0
+label: Panels
+variant: panels_variant
+variant_settings:
+  blocks:
+    4fe295c8-8fd2-44fd-a8c0-65d71579f4de:
+      id: page_title_block
+      label: 'Page title'
+      provider: core
+      label_display: '0'
+      region: title
+      weight: 0
+      uuid: 4fe295c8-8fd2-44fd-a8c0-65d71579f4de
+      context_mapping: {  }
+  id: panels_variant
+  uuid: dba05a1b-0070-4e7d-8720-305b76b61827
+  label: null
+  weight: 0
+  layout: pattern_jumbotron
+  layout_settings: {  }
+  page_title: 'Here is your jumbotron title'
+  storage_type: page_manager
+  storage_id: panels_test_page-panels_variant-0
+  builder: standard
+page: panels_test_page
+weight: 0
+selection_criteria: {  }
+selection_logic: and
+static_context: {  }

--- a/tests/features/content.feature
+++ b/tests/features/content.feature
@@ -82,3 +82,7 @@ Feature: Content
     And I should see the button "Save changes" in the "modal"
     And I should see the link "Link title"
 
+  Scenario: Patterns render as Panels layouts.
+    Given I am on "/panels-test-page"
+    Then I should see "Here is your jumbotron title" in the "modal"
+


### PR DESCRIPTION
When the patterns_layouts module is enabled and a UI Patterns is selected as a layout in a panel, nothing is rendered on the corresponding page(s). The layout is correctly loaded in the backend (i.e. in Panel's admin content manager), but when the page is rendered the content output is empty.

I believe this is actually the cause [of a core bug](https://www.drupal.org/node/2070131) that improperly merges element defaults for any of the element callback properties. The rough explanation of what's happening is

- `Drupal\panels\Plugin\DisplayBuilder\StandardDisplayBuilder::build()` attempts to build the page using the configured layout which calls:
- `Drupal\ui_patterns_layouts\Plugin\Layout\PatternLayout::build()` which returns a pattern render array
- The pattern render array bubbles up the render pipeline and eventually gets to `Drupal\Core\Entity\Controller\EntityViewController::view()` which adds a pre_render callback directly on the pattern render array element (this is the problem)
- Finally, the element is rendered by `Drupal\Core\Render\Renderer::doRender()` which uses an array union to merge the elementInfo defaults. Since there is already a pre_render callback in there, the defaults are skipped and the pattern doesn't render properly.

I'm currently working on a Core fix, but my patch kinda exploded on the last test run. Also since it's core it could take a while, or possibly never be approved so here I am. I think just manually merging the defaults in our `PatternLayout::build()` method should do the trick and doesn't break any rules. Defaults are defaults so it shouldn't matter at what point they're merged. It's also possible that some of the other ui_pattern submodules could benefit from this merge as well, but this case is the only one I've experienced with this issue so far.

Thanks!