### PR TITLE
Expose UI Patterns ID to twig

### DIFF
--- a/src/Plugin/PatternBase.php
+++ b/src/Plugin/PatternBase.php
@@ -152,6 +152,7 @@ abstract class PatternBase extends PluginBase implements PatternInterface, Conta
    */
   protected function processVariables(PatternDefinition $definition) {
     $return = [];
+    $return['variables']['ui_patterns_id'] = $definition->id();
     foreach ($definition->getFields() as $field) {
       $return['variables'][$field->getName()] = NULL;
     }


### PR DESCRIPTION
Hi, sorry for my bad english.

I need to know which pattern is going to be rendered as a workaround for the absence of modifiers #119 .

For this, and other reasons, it would be helpful to expose the ui_patterns_id to the twig file.

I'm currently using this new variable as follows:

<pre>
cta:
  label: 'CTA'
  description: 'Display a CTA.'
  fields:
    title:
      type: 'text'
      label: 'Title'
      description: 'The CTA title.'
      preview: 'Lorem ipsum dolor sit'
    subtitle:
      type: 'text'
      label: 'Subtitle'
      description: 'The CTA subtitle.'
      preview: '&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;p&gt;'
    image_uri:
      type: 'image'
      label: 'Image URI'
      description: 'The CTA background image uri.'
      preview: 'https://unsplash.it/1920/600/?image=1074'
    link:
      type: 'link'
      label: 'Link'
      description: 'The CTA link (use the "Link CTA" pattern).'
      preview:
        type: 'pattern'
        id: 'link_cta'
        fields:
          title: 'Esplora'
          uri: 'http://example.com'

cta_black:
  label: 'CTA Black'
  description: 'Display a CTA variant (Black).'
  use: '@mytheme/patterns/cta/pattern-cta.html.twig'
  fields:
    title:
      type: 'text'
      label: 'Title'
      description: 'The CTA title.'
      preview: 'Lorem ipsum dolor sit'
    subtitle:
      type: 'text'
      label: 'Subtitle'
      description: 'The CTA subtitle.'
      preview: '&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;p&gt;'
    image_uri:
      type: 'image'
      label: 'Image URI'
      description: 'The CTA background image uri.'
      preview: 'https://unsplash.it/1920/600/?image=1055'
    link:
      type: 'link'
      label: 'Link'
      description: 'The CTA link (use the "Link CTA" pattern).'
      preview:
        type: 'pattern'
        id: 'link_cta'
        fields:
          title: 'Esplora'
          uri: 'http://example.com'

cta_h_t_r:
  label: 'CTA H-T-R'
  description: 'Display a CTA variant (H-T-R).'
  use: '@mytheme/patterns/cta/pattern-cta.html.twig'
  fields:
    title:
      type: 'text'
      label: 'Title'
      description: 'The CTA title.'
      preview: 'Lorem ipsum dolor sit'
    subtitle:
      type: 'text'
      label: 'Subtitle'
      description: 'The CTA subtitle.'
      preview: '&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;p&gt;'
    image_uri:
      type: 'image'
      label: 'Image URI'
      description: 'The CTA background image uri.'
      preview: 'https://unsplash.it/1920/600/?image=831'
    link:
      type: 'link'
      label: 'Link'
      description: 'The CTA link (use the "Link CTA" pattern).'
      preview:
        type: 'pattern'
        id: 'link_cta'
        fields:
          title: 'Esplora'
          uri: 'http://example.com'
</pre>

<pre>
{#
/**
 * @file
 * CTA pattern.
 */
#}
{# Until https://github.com/nuvoleweb/ui_patterns/issues/118 is completed, simulate variants. #}
{% if modifier is empty %}
    {% set modifiers = {
        'cta': '',
        'cta_black': 'black',
        'cta_h_t_r': 'h-t-r',
        }
    %}
    {% set modifier = attribute(modifiers, ui_patterns_id) %}
{% endif %}
{% if modifier is not empty %}
    {% set variant = 'mytheme-cta--' ~ modifier %}
{% endif %}

{# Clean the image_uri field to avoid problems with active debugging. #}
{% set image_uri = image_uri|render|striptags %}
&lt;article class="mytheme-cta mytheme-cta--overlay {{ variant }}"
         style="background-image: url({{ image_uri }})"&gt;
    &lt;div class="mytheme-cta__content"&gt;
        &lt;h4 class="mytheme-cta__content__title"&gt;
            {{ title }}
        &lt;/h4&gt;
        {{ subtitle }}
        {{ link }}
    &lt;/div&gt;
&lt;/article&gt;
</pre>