### PR TITLE
Overwrite module defined patterns on theme layer

### DIFF
--- a/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
+++ b/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
@@ -165,7 +165,7 @@ class LibraryDeriver extends AbstractYamlPatternsDeriver {
       }
     }
 
-    return $directories + $this->moduleHandler->getModuleDirectories();
+    return $this->moduleHandler->getModuleDirectories() + $directories;
   }
 
   /**


### PR DESCRIPTION
We want to build "kind-of" base components/ ui_patterns in a module. Those patterns can be used "as is" or can be overridden on theme-layer. Best example for such a usecase would be a slider - default would be a slick slider. The slider is fine for most cases, but in some special cases, we want to use a custom library for the slider in our theme. Instead of using a hook alter function or creating a new pattern, the theme-dev would just duplicate the pattern in the theme and change the libraries definition.