### PR TITLE
Include the current views_row as a context

### DIFF
--- a/modules/ui_patterns_views/ui_patterns_views.module
+++ b/modules/ui_patterns_views/ui_patterns_views.module
@@ -63,6 +63,7 @@ function template_preprocess_pattern_views_row(array &$variables) {
     $variables['pattern']['#context']['view_name'] = $view->storage->id();
     $variables['pattern']['#context']['display'] = $view->current_display;
     $variables['pattern']['#context']['view'] = $view;
+    $variables['pattern']['#context']['row'] = $row;
   }
 }
 


### PR DESCRIPTION
It would be good to include the current views_row as a context in the preprocessor when using ui_pattern_views to override the row template with a pattern. It's handy if you, say, need to pass some field data that is for preprocessing but doesn't necessarily belong in a pattern field.