### PR TITLE
Layout builder "Add Block" links not renderd in patterns

### DIFF
--- a/src/Element/Pattern.php
+++ b/src/Element/Pattern.php
@@ -93,7 +93,24 @@ class Pattern extends RenderElement {
       }
     }
     else {
-      $element['#markup'] = '';
+      // There are maybe regions added to the pattern by third party modules.
+      // For example layout builder adds the 'Add Block' link.
+      // Check if the sub element matches a field name.
+      // If the name match remap it.
+      $definition = UiPatterns::getPatternDefinition($element['#id']);
+      // Check if the pattern is empty.
+      $empty_fields = TRUE;
+      foreach ($definition->getFields() as $key => $field) {
+        if (isset($element[$key])) {
+          $element['#' . $key] = $element[$key];
+          unset($element[$key]);
+          $empty_fields = FALSE;
+        }
+      }
+
+      if ($empty_fields == TRUE) {
+        $element['#markup'] = '';
+      }
     }
     return $element;
   }


### PR DESCRIPTION
Layout builder adds the "Add block" links as child renderable array to the pattern.
@see \Drupal\layout_builder\Controller\LayoutBuilderController:195
Map the keys to field compatible field keys in Element\Pattern.

Not 100% sure if this is the right place OR layou builder should do something differnt.