### PR TITLE
Improve performance of pattern theme hook check

### DIFF
--- a/src/UiPatternsManager.php
+++ b/src/UiPatternsManager.php
@@ -27,6 +27,13 @@ class UiPatternsManager extends DefaultPluginManager implements PluginManagerInt
   protected $themeHandler;
 
   /**
+   * An array of pattern theme hooks for fast lookup.
+   *
+   * @var array
+   */
+  protected $patternHooks;
+
+  /**
    * UiPatternsManager constructor.
    */
   public function __construct(\Traversable $namespaces, ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler, CacheBackendInterface $cache_backend) {
@@ -85,10 +92,12 @@ class UiPatternsManager extends DefaultPluginManager implements PluginManagerInt
    * {@inheritdoc}
    */
   public function isPatternHook($hook) {
-    $definitions = array_filter($this->getDefinitions(), function (PatternDefinition $definition) use ($hook) {
-      return $definition->getThemeHook() == $hook;
-    });
-    return !empty($definitions);
+    if (empty($this->patternHooks)) {
+      foreach ($this->getDefinitions() as $definition) {
+        $this->patternHooks[$definition->getThemeHook()] = $definition->getThemeHook();
+      }
+    }
+    return !empty($this->patternHooks[$hook]);
   }
 
   /**


### PR DESCRIPTION
The check for if a theme hook belongs to a pattern gets called a lot on uncached pages. Enough so that the repeated array_filter calls makes for a non-trivial performance hit (~600ms on an average speed server, medium sized site).

I propose we store all the pattern hooks in a class property and just do a simple array lookup when isPatternHook is called.