### PR TITLE
According to Drupal standards, modules should include dependencies in the .info.yml file.

### DIFF
--- a/modules/ui_patterns_ds/ui_patterns_ds.info.yml
+++ b/modules/ui_patterns_ds/ui_patterns_ds.info.yml
@@ -4,5 +4,5 @@ description: Use patterns as Display Suite field templates. It also provides Dis
 core: 8.x
 package: User interface
 dependencies:
-  - ds
-  - ui_patterns
+  - ds:ds
+  - ui_patterns:ui_patterns

--- a/modules/ui_patterns_field_group/ui_patterns_field_group.info.yml
+++ b/modules/ui_patterns_field_group/ui_patterns_field_group.info.yml
@@ -4,5 +4,5 @@ description: Use patterns as field groups templates.
 core: 8.x
 package: User interface
 dependencies:
-  - field_group
-  - ui_patterns
+  - field_group:field_group
+  - ui_patterns:ui_patterns

--- a/modules/ui_patterns_layouts/ui_patterns_layouts.info.yml
+++ b/modules/ui_patterns_layouts/ui_patterns_layouts.info.yml
@@ -4,5 +4,5 @@ description: Use patterns as layouts via the Layout Discovery module.
 core: 8.x
 package: User interface
 dependencies:
-  - layout_discovery
-  - ui_patterns
+  - drupal:layout_discovery
+  - ui_patterns:ui_patterns

--- a/modules/ui_patterns_library/ui_patterns_library.info.yml
+++ b/modules/ui_patterns_library/ui_patterns_library.info.yml
@@ -4,4 +4,4 @@ description: Exposed patterns in you modules and themes and display them in a pa
 core: 8.x
 package: User interface
 dependencies:
-  - ui_patterns
+  - ui_patterns:ui_patterns

--- a/modules/ui_patterns_test/ui_patterns_test.info.yml
+++ b/modules/ui_patterns_test/ui_patterns_test.info.yml
@@ -5,34 +5,34 @@ core: 8.x
 hidden: true
 package: 'User interface'
 dependencies:
-  - block
-  - coffee
-  - comment
-  - ds
-  - entity_reference_revisions
+  - drupa:block
+  - coffee:coffee
+  - drupal:comment
+  - ds:ds
+  - entity_reference_revisions:entity_reference_revisions
   - features_ui
-  - field
+  - drupal:field
   - field_group
-  - help
-  - image
-  - link
-  - node
-  - page_manager
-  - page_manager_ui
-  - panels
-  - paragraphs
-  - path
-  - search
-  - simpletest
-  - system
-  - text
-  - token
-  - ui_patterns
-  - ui_patterns_ds
-  - ui_patterns_field_group
-  - ui_patterns_layouts
-  - ui_patterns_library
-  - ui_patterns_views
-  - user
-  - views
-  - views_ui
+  - drupal:help
+  - drupal:image
+  - drupal:link
+  - drupal:node
+  - page_manager:page_manager
+  - page_manager:page_manager_ui
+  - panels:panels
+  - paragraphs:paragraphs
+  - drupal:drupal:path
+  - drupal:search
+  - drupal:simpletest
+  - drupal:system
+  - drupal:text
+  - token:token
+  - ui_patterns:ui_patterns
+  - ui_patterns:ui_patterns_ds
+  - ui_patterns:ui_patterns_field_group
+  - ui_patterns:ui_patterns_layouts
+  - ui_patterns:ui_patterns_library
+  - ui_patterns: ui_patterns_views
+  - drupal:user
+  - drupal:views
+  - drupal:views_ui

--- a/modules/ui_patterns_views/ui_patterns_views.info.yml
+++ b/modules/ui_patterns_views/ui_patterns_views.info.yml
@@ -4,5 +4,5 @@ description: Use patterns as Views templates.
 core: 8.x
 package: User interface
 dependencies:
-  - views
-  - ui_patterns
+  - drupal:views
+  - ui_patterns:ui_patterns


### PR DESCRIPTION
According to Drupal standards, modules should include dependencies in the .info.yml file.
Dependencies should be namespaced in the format {project}:{module}, where {project} is the project name as it appears in the Drupal.org URL (e.g. drupal.org/project/views) and {module} is the module's machine name.

https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file