### PR TITLE
Missing @group in EntityFinderTest

### DIFF
--- a/modules/ui_patterns_field_group/tests/src/Unit/EntityFinderTest.php
+++ b/modules/ui_patterns_field_group/tests/src/Unit/EntityFinderTest.php
@@ -8,6 +8,8 @@ use Drupal\ui_patterns_field_group\Utility\EntityFinder;
 
 /**
  * Test entity finder utility.
+ *
+ * @group ui_patterns
  */
 class EntityFinderTest extends UnitTestCase {
 


### PR DESCRIPTION
The Drupal\Tests\ui_patterns_field_group\Unit\EntityFinderTest test did not have a @group defined in its annotation so would result in the following error message when run-tests.sh was started:

  Drupal\simpletest\Exception\MissingGroupException: Missing @group
  annotation in Drupal\Tests\ui_patterns_field_group\Unit\
  EntityFinderTest in core/modules/simpletest/src/TestDiscovery.php:360