### PR TITLE
Better pattern override hierarchy; refs #160

### DIFF
--- a/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
+++ b/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
@@ -159,13 +159,15 @@ class LibraryDeriver extends AbstractYamlPatternsDeriver {
 
     $directories = [];
     if (isset($theme_directories[$default_theme])) {
-      $directories[$default_theme] = $theme_directories[$default_theme];
       foreach ($base_themes as $name => $theme) {
         $directories[$name] = $theme_directories[$name];
       }
+      // Default theme can override definitions made in base themes.
+      $directories[$default_theme] = $theme_directories[$default_theme];
     }
 
-    return $directories + $this->moduleHandler->getModuleDirectories();
+    // Themes can override definitions made in modules.
+    return $this->moduleHandler->getModuleDirectories() + $directories;
   }
 
   /**

--- a/src/Definition/PatternSourceField.php
+++ b/src/Definition/PatternSourceField.php
@@ -11,9 +11,34 @@ class PatternSourceField {
 
   const FIELD_KEY_SEPARATOR = ':';
 
+  /**
+   * Field name.
+   *
+   * @var string
+   */
   private $fieldName;
+
+  /**
+   * Field label.
+   *
+   * @var string
+   */
   private $fieldLabel;
+
+  /**
+   * Plugin ID.
+   *
+   * @var string
+   */
+
   private $pluginId;
+
+  /**
+   * Plugin label.
+   *
+   * @var string
+   */
+
   private $pluginLabel;
 
   /**


### PR DESCRIPTION
  Pattern definitions get priority in the folllowing order:
    * Modules
    * Base theme(s)
    * Default theme

  Thus, definitions in the default theme get the most priority.