### PR TITLE
Issue #267: Don't store absolute base path to avoid cache issues.

### DIFF
--- a/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
+++ b/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
@@ -131,7 +131,7 @@ class LibraryDeriver extends AbstractYamlPatternsDeriver {
           $content = file_get_contents($file_path);
           foreach (Yaml::decode($content) as $id => $definition) {
             $definition['id'] = $id;
-            $definition['base path'] = dirname($file_path);
+            $definition['base path'] = str_replace($this->root, '', dirname($file_path));
             $definition['file name'] = basename($file_path);
             $definition['provider'] = $provider;
             $patterns[] = $this->getPatternDefinition($definition);

--- a/src/Plugin/PatternBase.php
+++ b/src/Plugin/PatternBase.php
@@ -79,8 +79,7 @@ abstract class PatternBase extends PluginBase implements PatternInterface, Conta
 
     // Attach pattern base path to assets.
     if (!empty($definition['base path'])) {
-      $base_path = str_replace($this->root, '', $definition['base path']);
-      $this->processLibraries($items, $base_path);
+      $this->processLibraries($items, $definition['base path']);
     }
 
     // Produce final libraries array.


### PR DESCRIPTION
This should resolve the issue discussed in #267. By moving the str_replace of the drupal root to earlier in the process, it keeps it from being cached in the cache_discovery table, which avoids problem when code is deployed on a cloud environment and the storage binding changes in the path on the server.