### PR TITLE
275 form fields processing

### DIFF
--- a/src/Element/Pattern.php
+++ b/src/Element/Pattern.php
@@ -86,7 +86,7 @@ class Pattern extends RenderElement {
   public static function processFields(array $element) {
     // Make sure we don't render anything in case fields are empty.
     if (self::hasFields($element)) {
-      $fields = $element['#fields'];
+      $fields = isset($element['#fields']) ? $element['#fields'] : [];
 
       // Add children elements as fields.
       foreach (Element::children($element) as $children_key) {

--- a/src/Element/Pattern.php
+++ b/src/Element/Pattern.php
@@ -90,7 +90,9 @@ class Pattern extends RenderElement {
 
       // Add children elements as fields.
       foreach (Element::children($element) as $children_key) {
-        $fields[$children_key] = $element[$children_key];
+        if (!isset($fields[$children_key])) {
+          $fields[$children_key] = $element[$children_key];
+        }
       }
 
       unset($element['#fields']);

--- a/src/Element/Pattern.php
+++ b/src/Element/Pattern.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ui_patterns\Element;
 
+use Drupal\Core\Render\Element;
 use Drupal\Core\Render\Element\RenderElement;
 use Drupal\Core\Template\Attribute;
 use Drupal\ui_patterns\UiPatterns;
@@ -86,6 +87,12 @@ class Pattern extends RenderElement {
     // Make sure we don't render anything in case fields are empty.
     if (self::hasFields($element)) {
       $fields = $element['#fields'];
+
+      // Add children elements as fields.
+      foreach (Element::children($element) as $children_key) {
+        $fields[$children_key] = $element[$children_key];
+      }
+
       unset($element['#fields']);
 
       foreach ($fields as $name => $field) {
@@ -206,7 +213,8 @@ class Pattern extends RenderElement {
    *   TRUE or FALSE.
    */
   public static function hasFields(array $element) {
-    return isset($element['#fields']) && !empty($element['#fields']) && is_array($element['#fields']);
+    $has_fields = isset($element['#fields']) && !empty($element['#fields']) && is_array($element['#fields']);
+    return $has_fields || !empty(Element::children($element));
   }
 
   /**


### PR DESCRIPTION
Initial approach to make form fields be processed. This proposes an additional / alternate way to define pattern fields content in render arrays, by adding them as direct regular render children as follows:


```
    $form['content'] = [
      '#type' => 'pattern',
      '#id' => 'call_to_action',
      '#variant' => 'jumbotron',
      'title' => [
        '#markup' => $this->t('Explore our catalog'),
      ],
      'lead' => [
        'text' => [
          '#type' => 'textfield',
          '#required' => TRUE,
          '#placeholder' => $this->t('Product name, brand, reference...'),
        ],
      ],
      'action_link' => [
        'actions' => [
          '#type' => 'actions',
          'submit' => [
            '#type' => 'submit',
            '#value' => $this->t('Search'),
          ],
        ],
      ],
    ];

```
