### PR TITLE
Fix #274: Allow for Layout Builder sections to be given administrativ…

### DIFF
--- a/modules/ui_patterns_layouts/src/Plugin/Layout/PatternLayout.php
+++ b/modules/ui_patterns_layouts/src/Plugin/Layout/PatternLayout.php
@@ -119,7 +119,7 @@ class PatternLayout extends LayoutDefault implements PluginFormInterface, Contai
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $configuration = $this->getConfiguration();
-    $form = [];
+    $form = parent::buildConfigurationForm($form, $form_state);
 
     $form['pattern'] = [
       '#group' => 'additional_settings',


### PR DESCRIPTION
…e labels

See also: https://github.com/nuvoleweb/ui_patterns/issues/274

Drupal 8.8 will be released soon with an improvement about Layout Management which make the layout builder more usable : Allow for Layout Builder sections to be given administrative labels
https://www.drupal.org/node/3073872

However, this is not working with layouts generated by ui_patterns_layout because Drupal\ui_patterns_layouts\Plugin\Layout\PatternLayout::buildConfigurationForm() is ignoring its parent method.