### PR TITLE
Provide 'base theme' definition for test theme.

### DIFF
--- a/modules/ui_patterns_library/tests/modules/ui_patterns_library_theme_test/ui_patterns_library_theme_test.info.yml
+++ b/modules/ui_patterns_library/tests/modules/ui_patterns_library_theme_test/ui_patterns_library_theme_test.info.yml
@@ -1,3 +1,4 @@
 name: 'UI Patterns library theme test'
 type: theme
 core: 8.x
+base theme: stable


### PR DESCRIPTION
Per a change in core 8.8.0, the "base theme" property is required on all themes:
https://www.drupal.org/node/3066038

The test theme included in the UI Patterns project did not include this line, so I've added one that uses the "stable" theme.