### PR TITLE
Adds pattern fields with no value to the render as empty

### DIFF
--- a/src/Element/Pattern.php
+++ b/src/Element/Pattern.php
@@ -88,9 +88,12 @@ class Pattern extends RenderElement {
       $fields = $element['#fields'];
       unset($element['#fields']);
 
-      foreach ($fields as $name => $field) {
+      $definition = UiPatterns::getPatternDefinition($element['#id']);
+      foreach ($definition->getFields() as $field_definition) {
+        $name = $field_definition->getName();
         $key = '#' . $name;
-        $element[$key] = $field;
+        // Enforce that fields with no value are rendered empty.
+        $element[$key] = isset($fields[$name]) ? $fields[$name] : ['#markup' => ''];
       }
     }
     else {


### PR DESCRIPTION
I found that having a pattern with a field that has the same name as a source field, if the pattern field is empty but the source field is mapped into another pattern field, the source field value is rendered in the pattern field with the same name.

E.g., an entity with a base field named "title" rendered using a layout pattern which has also a field named "title". The pattern title field has no placements in the layout (it is empty), and the entity title field is placed elsewhere in the layout. The value of the entity title is shown in the pattern title field.

#101 might be related to this.