### PR TITLE
Process the definition via layout plugin manager, so the new plugin get fully populated.

### DIFF
--- a/modules/ui_patterns_layouts/ui_patterns_layouts.module
+++ b/modules/ui_patterns_layouts/ui_patterns_layouts.module
@@ -18,6 +18,9 @@ use Drupal\field_layout\Display\EntityDisplayWithLayoutInterface;
 function ui_patterns_layouts_layout_alter(&$definitions) {
   /** @var \Drupal\ui_patterns\Definition\PatternDefinition[] $pattern_definitions */
 
+  /** @var  \Drupal\Core\Layout\LayoutPluginManager $layout_plugin_manager */
+  $layout_plugin_manager = \Drupal::service('plugin.manager.core.layout');
+
   // @todo: Use layout deriver instead.
   // @link https://github.com/nuvoleweb/ui_patterns/issues/94
   foreach (UiPatterns::getPatternDefinitions() as $pattern_definition) {
@@ -33,7 +36,15 @@ function ui_patterns_layouts_layout_alter(&$definitions) {
     foreach ($pattern_definition->getFields() as $field) {
       $definition['regions'][$field->getName()]['label'] = $field->getLabel();
     }
-    $definitions['pattern_' . $pattern_definition->id()] = new LayoutDefinition($definition);
+
+    // Process the definition via layout plugin manager, so the new plugin get
+    // fully populated.
+    $layout_definition = new LayoutDefinition($definition);
+    $plugin_id = 'pattern_' . $pattern_definition->id();
+
+    $layout_plugin_manager->processDefinition($layout_definition, $plugin_id);
+
+    $definitions[$plugin_id] = $layout_definition;
   }
 }
 


### PR DESCRIPTION
As long as the plugin manager process the definition individually there would be no performance impact.
Without the patch \Drupal\Core\Layout\LayoutPluginManager::getThemeImplementations() process wrongly the layout patterns