### PR TITLE
Sanitise hyphens when using pattern id as theme hook

### DIFF
--- a/src/Definition/PatternDefinition.php
+++ b/src/Definition/PatternDefinition.php
@@ -65,7 +65,10 @@ class PatternDefinition extends PluginDefinition implements DerivablePluginDefin
     $this->id = $this->definition['id'];
     $this->setFields($this->definition['fields']);
     $this->setVariants($this->definition['variants']);
-    $this->setThemeHook(self::PATTERN_PREFIX . $this->id());
+    // As we know allow hyphens the pattern ID, we need to sanitise it when
+    // setting pattern theme hook.
+    $hookFriendlyId = str_replace('-', '_', $this->id());
+    $this->setThemeHook(self::PATTERN_PREFIX . $hookFriendlyId);
 
     if (!empty($definition['theme hook'])) {
       $this->setThemeHook($definition['theme hook']);

--- a/src/Definition/PatternDefinition.php
+++ b/src/Definition/PatternDefinition.php
@@ -65,10 +65,10 @@ class PatternDefinition extends PluginDefinition implements DerivablePluginDefin
     $this->id = $this->definition['id'];
     $this->setFields($this->definition['fields']);
     $this->setVariants($this->definition['variants']);
-    // As we know allow hyphens the pattern ID, we need to sanitise it when
-    // setting pattern theme hook.
-    $hookFriendlyId = str_replace('-', '_', $this->id());
-    $this->setThemeHook(self::PATTERN_PREFIX . $hookFriendlyId);
+    // As we now allow hyphens in pattern IDs we need to turn them into
+    // underscores when setting the theme hook.
+    $hook_friendly_id = str_replace('-', '_', $this->id());
+    $this->setThemeHook(self::PATTERN_PREFIX . $hook_friendly_id);
 
     if (!empty($definition['theme hook'])) {
       $this->setThemeHook($definition['theme hook']);

--- a/tests/modules/ui_patterns_render_test/templates/pattern-foo-bar.html.twig
+++ b/tests/modules/ui_patterns_render_test/templates/pattern-foo-bar.html.twig
@@ -1,1 +1,1 @@
-Foo Bar
+Foo Bar default template

--- a/tests/src/Functional/UiPatternsPreviewRenderTest.php
+++ b/tests/src/Functional/UiPatternsPreviewRenderTest.php
@@ -59,6 +59,19 @@ class UiPatternsPreviewRenderTest extends BrowserTestBase {
     foreach ($suggestions as $suggestion) {
       $assert_session->responseContains($suggestion);
     }
+
+    // Pattern foo-bar default template is loaded.
+    $assert_session->pageTextContains('Foo Bar default template');
+    $assert_session->pageTextNotContains('Foo Bar overridden template');
+
+    // Install test theme to load template(s) overrides.
+    $this->container->get('theme_installer')->install(['ui_patterns_theme_test']);
+    $this->container->get('theme_handler')->setDefault('ui_patterns_theme_test');
+    $this->container->set('theme.registry', NULL);
+
+    $this->drupalGet('/patterns');
+    $assert_session->pageTextContains('Foo Bar overridden template');
+    $assert_session->pageTextNotContains('Foo Bar default template');
   }
 
 }

--- a/tests/themes/ui_patterns_theme_test/pattern-foo-bar--variant-default--preview.html.twig
+++ b/tests/themes/ui_patterns_theme_test/pattern-foo-bar--variant-default--preview.html.twig
@@ -1,0 +1,1 @@
+Foo Bar overridden template

--- a/tests/themes/ui_patterns_theme_test/ui_patterns_theme_test.info.yml
+++ b/tests/themes/ui_patterns_theme_test/ui_patterns_theme_test.info.yml
@@ -1,0 +1,4 @@
+name: 'UI Patterns Test theme'
+type: theme
+description: 'Theme for testing UI Patterns features in action on a theme.'
+core: 8.x


### PR DESCRIPTION
With #243 we allowed hyphens as pattern id. Although this work perfectly, we haven't fully tested overriding patterns template through theme suggestions.

And indeed if there is a hyphen in the pattern id, overrides are not loaded.

This PR address this bug.