### PR TITLE
Fix field context for multiple sources in destination

### DIFF
--- a/src/Element/Pattern.php
+++ b/src/Element/Pattern.php
@@ -156,13 +156,14 @@ class Pattern extends RenderElement {
         if (count($field) > 1) {
           /** @var \Drupal\ui_patterns\Element\PatternContext $context */
           $context = $element['#context'];
-          $context->setProperty('pattern', $element['#id']);
-          $context->setProperty('field', $name);
+          $field_context = new PatternContext($context->getType(), $context->getProperties());
+          $field_context->setProperty('pattern', $element['#id']);
+          $field_context->setProperty('field', $name);
 
           // Render multiple sources with "patterns_destination" template.
           $element['#fields'][$name] = [
             '#sources' => $field,
-            '#context' => $context,
+            '#context' => $field_context,
             '#theme' => 'patterns_destination',
           ];
         }

--- a/src/Element/PatternContext.php
+++ b/src/Element/PatternContext.php
@@ -50,6 +50,16 @@ class PatternContext {
   }
 
   /**
+   * Get pattern context properties.
+   *
+   * @return mixed
+   *   Property value.
+   */
+  public function getProperties() {
+    return $this->properties;
+  }
+
+  /**
    * Set pattern context property.
    *
    * @param string $name

--- a/src/Element/PatternContext.php
+++ b/src/Element/PatternContext.php
@@ -53,7 +53,7 @@ class PatternContext {
    * Get pattern context properties.
    *
    * @return mixed
-   *   Property value.
+   *   All context properties.
    */
   public function getProperties() {
     return $this->properties;


### PR DESCRIPTION
This fixes a bug when a pattern has multiple destinations with multiple sources. The context for every field is always the same, because the context property is set on the same instance during the loop.

My proposed fix is to create a new instance of PatternContext which inherits the properties and then setting the field specific property.