### PR TITLE
Test-only: Demonstrate multitheme bug

### DIFF
--- a/modules/ui_patterns_library/tests/src/FunctionalJavascript/UiPatternsLibraryAlternativeThemeTest.php
+++ b/modules/ui_patterns_library/tests/src/FunctionalJavascript/UiPatternsLibraryAlternativeThemeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\Tests\ui_patterns_library\FunctionalJavascript;
+
+/**
+ * Test patterns overview page displays for non-default themes.
+ *
+ * @group ui_patterns_library
+ */
+class UiPatternsLibraryAlternativeThemeTest extends UiPatternsLibraryOverviewTest {
+
+  /**
+   * Default theme.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $active_theme = $this->container->get('theme.initialization')->initTheme('ui_patterns_library_theme_test');
+    $this->container->get('theme.manager')->setActiveTheme($active_theme);
+  }
+
+}


### PR DESCRIPTION
This is a test-only PR to demonstrate the issue in #308. 

Unfortunately, I'm shooting blind writing this test as I was experiencing weird chrome issues inside of my docker container when attempting to run the tests. 

Essentially, I'm reusing the other tests that already work, but simply setting the default theme to `stark` and then using the theme manager to switch the theme prior to running the tests. I will open a separate PR that includes the proposed fix. 
