### PR TITLE
Issue#304: Detect all theme patterns.

### DIFF
--- a/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
+++ b/modules/ui_patterns_library/src/Plugin/Deriver/LibraryDeriver.php
@@ -154,27 +154,14 @@ class LibraryDeriver extends AbstractYamlPatternsDeriver {
   /**
    * Create a list of all directories to scan.
    *
-   * This includes all module directories and directories of the default theme
-   * and all of its possible base themes.
+   * This includes all module and theme directories.
    *
    * @return array
    *   An array containing directory paths keyed by their extension name.
    */
-  protected function getDirectories() {
-    $default_theme = $this->themeHandler->getDefault();
-    $base_themes = $this->themeHandler->getBaseThemes($this->themeHandler->listInfo(), $default_theme);
-    $theme_directories = $this->themeHandler->getThemeDirectories();
-
-    $directories = [];
-    if (isset($theme_directories[$default_theme])) {
-      $directories[$default_theme] = $theme_directories[$default_theme];
-      foreach ($base_themes as $name => $theme) {
-        $directories[$name] = $theme_directories[$name];
-      }
-    }
-
-    return $directories + $this->moduleHandler->getModuleDirectories();
-  }
+   protected function getDirectories() {
+     return $this->moduleHandler->getModuleDirectories() + $this->themeHandler->getThemeDirectories();
+   }
 
   /**
    * Get extension name that hosts the given YAML definition file.

--- a/modules/ui_patterns_library/tests/fixtures/overview-page-patterns.yml
+++ b/modules/ui_patterns_library/tests/fixtures/overview-page-patterns.yml
@@ -1,48 +1,3 @@
-- name: 'simple'
-  label: 'Simple'
-  description: 'A simple pattern'
-  has_variants: false
-  preview: '<div class="pattern-simple">Simple pattern field</div>'
-  fields:
-  - name: 'field'
-    type: 'string'
-    label: 'Field'
-    description: 'Field description'
-
-- name: 'with_variants'
-  label: 'With variants'
-  description: 'Pattern with variants'
-  has_variants: true
-  preview: ~
-  fields:
-  - name: 'field'
-    type: 'string'
-    label: 'Field'
-    description: 'Field description'
-  variants:
-  - meta:
-      name: 'one'
-      label: 'One'
-      description: 'First variant'
-    preview: '<div class="pattern-with-variant-one">With variants pattern field</div>'
-  - meta:
-      name: 'two'
-      label: 'Two'
-      description: 'Second variant'
-    preview: '<div class="pattern-with-variant-two">With variants pattern field</div>'
-
-- name: 'with_custom_theme_hook'
-  theme hook: 'custom_theme_hook'
-  label: 'With custom theme hook'
-  description: 'Pattern with custom theme hook.'
-  has_variants: false
-  preview: 'With custom theme hook: Pattern field value'
-  fields:
-  - name: 'field'
-    type: 'string'
-    label: 'Field'
-    description: 'Field description'
-
 - name: 'button'
   label: 'Button'
   description: 'A simple button.'
@@ -97,3 +52,48 @@
     type: 'string'
     label: 'Field'
     description: 'Field description'
+
+- name: 'simple'
+  label: 'Simple'
+  description: 'A simple pattern'
+  has_variants: false
+  preview: '<div class="pattern-simple">Simple pattern field</div>'
+  fields:
+    - name: 'field'
+      type: 'string'
+      label: 'Field'
+      description: 'Field description'
+
+- name: 'with_variants'
+  label: 'With variants'
+  description: 'Pattern with variants'
+  has_variants: true
+  preview: ~
+  fields:
+    - name: 'field'
+      type: 'string'
+      label: 'Field'
+      description: 'Field description'
+  variants:
+    - meta:
+        name: 'one'
+        label: 'One'
+        description: 'First variant'
+      preview: '<div class="pattern-with-variant-one">With variants pattern field</div>'
+    - meta:
+        name: 'two'
+        label: 'Two'
+        description: 'Second variant'
+      preview: '<div class="pattern-with-variant-two">With variants pattern field</div>'
+
+- name: 'with_custom_theme_hook'
+  theme hook: 'custom_theme_hook'
+  label: 'With custom theme hook'
+  description: 'Pattern with custom theme hook.'
+  has_variants: false
+  preview: 'With custom theme hook: Pattern field value'
+  fields:
+    - name: 'field'
+      type: 'string'
+      label: 'Field'
+      description: 'Field description'


### PR DESCRIPTION
This PR attempts to solve multiple issues originating from the `\Drupal\ui_patterns_library\Plugin\Deriver\LibraryDeriver::getDirectories` method collecting only the default theme and the base theme directories.

Besides the issues described in #304 and #308, I also had errors during site install with existing config, when using patterns in layout builder, because during install the default theme is stark.

This PR is a follow up to PRs #305 and #310 and uses the method suggested here: https://github.com/nuvoleweb/ui_patterns/issues/304#issuecomment-687164731