### PR TITLE
Fix views preview when pattern declared by ui_pattern_library in the front theme.

### DIFF
--- a/src/Plugin/Deriver/AbstractPatternsDeriver.php
+++ b/src/Plugin/Deriver/AbstractPatternsDeriver.php
@@ -61,6 +61,7 @@ abstract class AbstractPatternsDeriver extends DeriverBase implements PatternsDe
     foreach ($this->getPatterns() as $pattern) {
       $pattern->setDeriver($base_plugin_definition['deriver']);
       $pattern->setClass($base_plugin_definition['class']);
+      $pattern->setProvider($base_plugin_definition['provider']);
       if ($this->isValidPatternDefinition($pattern)) {
         $this->derivatives[$pattern->id()] = $pattern;
       }


### PR DESCRIPTION
Without the provider, views cannot find the pattern template so the preview Ajax request throws an error 500.
With the provider, the pattern is used as expected.

---

Configuration:
* my pattern is declared in my frontend theme
* it is used by a content type view mode via ui_patterns_layouts and field_layouts
* the view list content of this type and display theme using this view mode