### PR TITLE
Ensure ui pattern field group form hooks run last

### DIFF
--- a/modules/ui_patterns_field_group/ui_patterns_field_group.module
+++ b/modules/ui_patterns_field_group/ui_patterns_field_group.module
@@ -9,6 +9,17 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\ui_patterns\Element\PatternContext;
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function ui_patterns_field_group_module_implements_alter(&$implementations, $hook) {
+  if ($hook === 'form_alter' && isset($implementations['ui_patterns_field_group'])) {
+    $group = $implementations['ui_patterns_field_group'];
+    unset($implementations['ui_patterns_field_group']);
+    $implementations['ui_patterns_field_group'] = $group;
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function ui_patterns_field_group_form_entity_view_display_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
The field group module reorders form alter hooks to make theirs run last. The ui pattern field group module adds a submit handler to the front of the submit array but for this to work as expected the field_group form alter needs to run before. This patch ensures the ui pattern field group form alters run after field_group, setting the correct submit handler order.

Please see, https://git.drupalcode.org/project/field_group/-/commit/dbdf8ba3962b4f8595436eb9153eb32f9b10900b