### PR TITLE
Add support for additional fields on PatternDefinitionField

### DIFF
--- a/src/Definition/PatternDefinitionField.php
+++ b/src/Definition/PatternDefinitionField.php
@@ -23,6 +23,7 @@ class PatternDefinitionField implements \ArrayAccess {
     'type' => NULL,
     'preview' => NULL,
     'escape' => TRUE,
+    'additional' => [],
   ];
 
   /**
@@ -159,6 +160,29 @@ class PatternDefinitionField implements \ArrayAccess {
    */
   public function setEscape($escape) {
     $this->definition['escape'] = $escape;
+    return $this;
+  }
+
+  /**
+   * Get Additional property.
+   *
+   * @return array
+   *   Property value.
+   */
+  public function getAdditional() {
+    return $this->definition['additional'];
+  }
+
+  /**
+   * Set Additional property.
+   *
+   * @param array $additional
+   *   Property value.
+   *
+   * @return $this
+   */
+  public function setAdditional(array $additional) {
+    $this->definition['additional'] = $additional;
     return $this;
   }
 


### PR DESCRIPTION
As with patterndefinitions, having an arbitrary additional on field definitions would allow to add custom data.